### PR TITLE
fix: `Model` should use `sliceSize` for sprites

### DIFF
--- a/lib/src/objects/model.dart
+++ b/lib/src/objects/model.dart
@@ -27,7 +27,7 @@ class Model extends SashimiObject {
 
   @override
   List<SashimiSlice> generateSlices() {
-    final sheet = SpriteSheet(image: image, srcSize: size.xy);
+    final sheet = SpriteSheet(image: image, srcSize: sliceSize.xy);
     final slices = (image.height / sliceSize.y).ceil();
 
     return [


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The `Model` was using the wrong value for the source size of a `Sprite`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
